### PR TITLE
Change deviceId in CommandRequest from number to String

### DIFF
--- a/src/devices.ts
+++ b/src/devices.ts
@@ -207,7 +207,7 @@ export function devices_relay_turn(devid:number,channel:number,state:boolean|str
 	let tosend:shelly_commandrequest_t={
 		"event":"Shelly:CommandRequest",
 		"trid":trid_src++,
-		"deviceId":devid,
+		"deviceId":String(devid),
 		"data":{
 		  "cmd":"relay",
 		  "params":{
@@ -231,7 +231,7 @@ export function devices_light_turn(devid:number, channel:number,state:boolean|st
 	let tosend:shelly_commandrequest_t={
 		event: 'Shelly:CommandRequest',
 		trid: trid_src++,
-		deviceId: devid,
+		deviceId: String(devid),
 		data: {
 			cmd: 'light',
 			params: {
@@ -256,7 +256,7 @@ export function devices_light_brightnes(devid:number,channel:number, value:unkno
 	let tosend:shelly_commandrequest_t={
 		event: 'Shelly:CommandRequest',
 		trid: trid_src++,
-		deviceId: devid,
+		deviceId: String(devid),
 		data: {
 			cmd: 'light',
 			params: {brightness: clamp(Number(value),0,100), id:channel}
@@ -335,7 +335,7 @@ export function devices_light_setup(devid:number,options:unknown, result_cb?:res
 		last_req={
 			event: 'Shelly:CommandRequest',
 			trid: trid_src++,
-			deviceId: devid,
+			deviceId: String(devid),
 			data: {
 				cmd: 'light',
 				params: p,
@@ -356,7 +356,7 @@ export function devices_ir_emit(devid:number,data:string, result_cb?:result_cb_t
 	let tosend:shelly_commandrequest_t={
 		event: 'Shelly:CommandRequest',
 		trid: trid_src++,
-		deviceId: devid,
+		deviceId: String(devid),
 		data: {
 			cmd: 'ir_emit',
 			params: {
@@ -376,7 +376,7 @@ export function devices_roller_go(devid:number, channel:number, go:string, durat
 	let tosend:shelly_commandrequest_t={
 		event: 'Shelly:CommandRequest',
 		trid: trid_src++,
-		deviceId: devid,
+		deviceId: String(devid),
 		data: {
 			cmd: 'roller',
 			params: {go: String(go), id:channel}
@@ -393,7 +393,7 @@ export function devices_roller_to_pos(devid:number, channel:number, pos:number, 
 	let tosend:shelly_commandrequest_t={
 		event: 'Shelly:CommandRequest',
 		trid: trid_src++,
-		deviceId: devid,
+		deviceId: String(devid),
 		data: {
 			cmd: 'roller_to_pos',
 			params: {

--- a/src/shelly_types.ts
+++ b/src/shelly_types.ts
@@ -245,7 +245,7 @@ export function shelly_devid_hex(devid:string):string{
 export type shelly_commandrequest_t={
 	"event":"Shelly:CommandRequest",
 	"trid":number,
-	"deviceId":number,
+	"deviceId":string,
 	"data":{
 		cmd:string;
 		params:Record<string,unknown>


### PR DESCRIPTION
I changed deviceId from _number_ to _String_ in CommandRequest as it was timing out with number. 
According to the [Shelly Real Time Events API docs](https://shelly-api-docs.shelly.cloud/cloud-control-api/real-time-events/#request-shellycommandrequest)  it should be string and this way it works.